### PR TITLE
Fixing references

### DIFF
--- a/_sources/Java4Python/commonmistakes.rst
+++ b/_sources/Java4Python/commonmistakes.rst
@@ -1,54 +1,60 @@
+.. _Common Mistakes:
+
 Common Mistakes
 ===============
 
+Forgetting to declare your variables
+------------------------------------
 
-    -  **Forgetting to declare your variables.**
+::
 
-       ::
+    Histo.java:21: cannot find symbol
+    symbol  : variable count
+    location: class Histo
+        count = new ArrayList<Integer>(10);
+        ^
 
-           Histo.java:21: cannot find symbol
-           symbol  : variable count
-           location: class Histo
-                   count = new ArrayList<Integer>(10);
-                   ^
+Not importing a class
+---------------------
 
-    -  **Not importing a class**:
+::
 
-       ::
+    Histo.java:9: cannot find symbol
+    symbol  : class Scanner
+    location: class Histo
+        Scanner data = null;
+        ^
 
-            Histo.java:9: cannot find symbol
-            symbol  : class Scanner
-            location: class Histo
-                    Scanner data = null;
-                    ^
+Forgetting to use the new keyword to create an object
+-----------------------------------------------------
+Here’s an example of the error message that occurs when you forget to
+use the new keyword. Notice that the message is pretty unhelpful.
+Java *thinks* you are trying to call the Method Scanner, but
+there are two problems. First Scanner is not really a method it
+is a constructor.:
 
-    -  **Forgetting to use the new keyword to create an object.** Here’s
-       an example of the error message that occurs when you forget to
-       use the new keyword. Notice that the message is pretty unhelpful.
-       Java *thinks* you are trying to call the Method Scanner, but
-       there are two problems. First Scanner is not really a method it
-       is a constructor.:
+::
 
-       ::
+    Histo.java:14: cannot find symbol
+    symbol  : method Scanner(java.io.File)
+    location: class Histo
+        data = Scanner(new File("test.dat"));
+               ^
 
-            Histo.java:14: cannot find symbol
-            symbol  : method Scanner(java.io.File)
-            location: class Histo
-                            data = Scanner(new File("test.dat"));
-                                   ^
+Forgetting a Semicolon
+----------------------
 
-    -  **Forgetting a Semicolon**:
+::
 
-       ::
+    Histo.java:19:
+    ';' expected
+        System.exit(0);
+        ^
 
-           Histo.java:19:
-           ';' expected
-                       System.exit(0);
-                       ^
+Forgetting to declare the kind of object in a container
+-------------------------------------------------------
 
-    -  Forgetting to declare the kind of object in a container.:
+::
 
-       ::
-
-             Note: Histo.java uses unchecked or unsafe operations. Note:
-             Recompile with -Xlint:unchecked for details.
+    Note: Histo.java uses unchecked or unsafe operations. Note:
+    Recompile with -Xlint:unchecked for details.

--- a/_sources/Java4Python/conditionals.rst
+++ b/_sources/Java4Python/conditionals.rst
@@ -181,8 +181,6 @@ alternative then the program would print(out both A and B.)
 Boolean Operators
 -----------------
 
-{sub:boolean\_operators}
-
 The conditionals used in the if statement can be boolean variables,
 simple comparisons, and compound boolean expressions.
 

--- a/_sources/Java4Python/firstjavaprogram.rst
+++ b/_sources/Java4Python/firstjavaprogram.rst
@@ -45,7 +45,7 @@ not worry! An important skill for a computer scientist is to learn what
 to ignore and what to look at carefully. You will soon find that there
 are some elements of Java that will fade into the background as you
 become used to seeing them. One thing that will help you is to learn a
-little bit about Java `Naming Conventions <namingconventions.html>`_.
+little bit about Java :ref:`Naming Conventions`.
 
 The first question you probably have about this little program is “How
 do I run it?” Running a Java program is not as simple as running a
@@ -70,7 +70,7 @@ The command ``javac`` compiles our java source code into compiled byte
 code and saves it in a file called ``Hello.class``. ``Hello.class`` is a
 binary file so you won’t learn much if you try to examine the class file
 with an editor. Hopefully you didn’t make any mistakes, but if you did
-you may want to consult the `Common Mistakes <commonmistakes.html>`_
+you may want to consult the :ref:`Common Mistakes`
 section for helpful hints on compiler errors.
 
 Now that we have compiled our java source code we can run the compiled

--- a/_sources/Java4Python/firstjavaprogram.rst
+++ b/_sources/Java4Python/firstjavaprogram.rst
@@ -45,7 +45,7 @@ not worry! An important skill for a computer scientist is to learn what
 to ignore and what to look at carefully. You will soon find that there
 are some elements of Java that will fade into the background as you
 become used to seeing them. One thing that will help you is to learn a
-little bit about Java [sec:naming\_conventions] {Naming Conventions}.
+little bit about Java `Naming Conventions <namingconventions.html>`_.
 
 The first question you probably have about this little program is “How
 do I run it?” Running a Java program is not as simple as running a
@@ -70,7 +70,7 @@ The command ``javac`` compiles our java source code into compiled byte
 code and saves it in a file called ``Hello.class``. ``Hello.class`` is a
 binary file so you won’t learn much if you try to examine the class file
 with an editor. Hopefully you didn’t make any mistakes, but if you did
-you may want to consult the [sec:common\_mistakes] {Common Mistakes}
+you may want to consult the `Common Mistakes <commonmistakes.html>`_
 section for helpful hints on compiler errors.
 
 Now that we have compiled our java source code we can run the compiled

--- a/_sources/Java4Python/javadatatypes.rst
+++ b/_sources/Java4Python/javadatatypes.rst
@@ -176,7 +176,7 @@ variable. If you have ever tried to use a Python variable that you have
 not initialized the second error message will be familiar to you. The
 difference here is that we see the message before we ever try to test
 our program. More common error messages are discussed in the section
-[sec:common\_mistakes] {Common Mistakes}.
+`Common Mistakes <commonmistakes.html>`_.
 
 The general rule in Java is that you must decide what kind of an object
 your variable is going to reference and then you must declare that

--- a/_sources/Java4Python/javadatatypes.rst
+++ b/_sources/Java4Python/javadatatypes.rst
@@ -176,7 +176,7 @@ variable. If you have ever tried to use a Python variable that you have
 not initialized the second error message will be familiar to you. The
 difference here is that we see the message before we ever try to test
 our program. More common error messages are discussed in the section
-`Common Mistakes <commonmistakes.html>`_.
+:ref:`Common Mistakes`.
 
 The general rule in Java is that you must decide what kind of an object
 your variable is going to reference and then you must declare that

--- a/_sources/Java4Python/namingconventions.rst
+++ b/_sources/Java4Python/namingconventions.rst
@@ -2,8 +2,6 @@
 Naming Conventions
 ==================
 
-{sec:naming\_conventions}
-
 Java has some very handy naming conventions.
 
 -  Class names always start with an upper case letter. For example,

--- a/_sources/Java4Python/namingconventions.rst
+++ b/_sources/Java4Python/namingconventions.rst
@@ -1,3 +1,4 @@
+.. _Naming Conventions:
 
 Naming Conventions
 ==================


### PR DESCRIPTION
Several references were formatted in a way that wasn't supported by Sphinx. I switched to the Sphinx-recommend way:
https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html

I also fixed the formatting on the Common Mistakes page, so everything wasn't indented.