### PR TITLE
I made the error messages in chapter9 cover multiple lines.

### DIFF
--- a/source/ch_9_commonmistakes.ptx
+++ b/source/ch_9_commonmistakes.ptx
@@ -10,13 +10,27 @@
     <section xml:id="forgetting-to-declare-your-variables">
         <title>Forgetting to declare your variables</title>
 
-        <pre>Histo.java:21: cannot find symbol symbol  : variable count location: class Histo count = new ArrayList&lt;Integer&gt;(10); ^</pre>
+        <pre>
+            Histo.java:21: cannot find symbol
+            symbol  : variable count
+            location: class Histo
+                count = new ArrayList&lt;Integer&gt;(10);
+                ^
+        </pre>
+
     </section>
 
     <section xml:id="not-importing-a-class">
         <title>Not importing a class</title>
 
-        <pre>Histo.java:9: cannot find symbol symbol  : class Scanner location: class Histo Scanner data = null; ^</pre>
+        <pre>
+            Histo.java:9: cannot find symbol
+            symbol  : class Scanner
+            location: class Histo
+                Scanner data = null;
+                ^
+        </pre>
+
     </section>
 
     <section xml:id="forgetting-to-use-the-new-keyword-to-create-an-object">
@@ -29,18 +43,35 @@
             First Scanner is not really a method it is a constructor.:
         </p>
 
-        <pre>Histo.java:14: cannot find symbol symbol  : method Scanner(java.io.File) location: class Histo data = Scanner(new File("test.dat")); ^</pre>
+        <pre>
+            Histo.java:14: cannot find symbol
+            symbol  : method Scanner(java.io.File)
+            location: class Histo
+                data = Scanner(new File("test.dat"));
+                ^
+        </pre>
+
     </section>
 
     <section xml:id="forgetting-a-semicolon">
         <title>Forgetting a Semicolon</title>
 
-        <pre>Histo.java:19: ';' expected System.exit(0); ^</pre>
+        <pre>
+            Histo.java:19:
+            ';' expected
+                System.exit(0);
+                ^
+        </pre>
+
     </section>
 
     <section xml:id="forgetting-to-declare-the-kind-of-object-in-a-container">
         <title>Forgetting to declare the kind of object in a container</title>
 
-        <pre>Note: Histo.java uses unchecked or unsafe operations. Note: Recompile with -Xlint:unchecked for details.</pre>
+        <pre>
+            Note: Histo.java uses unchecked or unsafe operations. Note:
+            Recompile with -Xlint:unchecked for details.
+        </pre>
+
     </section>
 </chapter>


### PR DESCRIPTION
all it does is make the error messages more readable. It looks like they got copy and pasted from the old book but didn't maintain their formatting. I went back and fixed the formatting so that they didn't show up as one continuous line.

##old
![image](https://github.com/user-attachments/assets/3e2795d9-d335-41a0-a9e8-59c332caa377)


##new
![image](https://github.com/user-attachments/assets/122ff113-049f-4ea2-9bab-0cec98262f75)

this fixes issue #15 