### PR TITLE
Added index to the main.ptx, have not added terms yet, commit for logan Fixes issue#20

### DIFF
--- a/source/main.ptx
+++ b/source/main.ptx
@@ -18,5 +18,11 @@
         <xi:include href="ch_9_commonmistakes.ptx" />
         <xi:include href="ch_10_moredocumentation.ptx" />
         <xi:include href="meta_backmatter.ptx" />
+
+        <index>
+            <title> Index </title>
+            <index-list/>
+        </index>
+
     </book>
 </pretext>


### PR DESCRIPTION
### Changes
I have added an `index` tag inside the `main.ptx` file, we have done this because of layering and not wanting extra clicks to have to be made by the user in order to use the index.

### Related issues
Fixes issue #20 

### Tested
Ran and built locally, approved by @coco3427 
waiting for approval from @pearcej 