### PR TITLE
8.1 adds python example of importing and a java comparison.

### DIFF
--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -37,6 +37,9 @@
             }
             </code> 
         </program>
+        <p>
+            Note the use of <c>import java.lang.Math;</c> in the above to import the Math class. Unlike Python, Java requires explicit imports for most libraries, including the <c>Math</c> class and many different classes for file handling.
+        </p>
 
         <p>
             Java has several libraries included for file handling, though, they must be imported. Java includes a class called <c>File</c> in the <c>io</c> library. The class can be imported with the following line. Be sure to capitalize <c>File</c>.

--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -13,11 +13,38 @@
 
     <section xml:id="file-class-import">
         <title>Class Imports</title>
+        <p>
+            In Python, most built-in libraries are available without needing  to explicitly import additional packages, but some libraries like <c>math</c> do need to be imported. Consider the following.
+        </p>
+        <p>
+            Python:
+        </p>
+        <program xml:id = "file-class-import-Python-example" interactive="activecode" language="python">
+            <code>
+            import math
+            print(math.sqrt(25))
+            </code> 
+        </program>
+
+        <p>
+            Java:
+        </p>
+        <program xml:id = "file-class-import-Java-example" interactive="activecode" language="java">
+            <code>
+            import java.lang.Math;
+
+            public class Main {
+                public static void main(String[] args) {
+                    System.out.println(Math.sqrt(25));
+                }
+            }
+            </code> 
+        </program>
 
         <p>
             Java has several libraries included for file handling, though, they must be imported. Java includes a class called <c>File</c> in the <c>io</c> library. The class can be imported with the following line. Be sure to capitalize <c>File</c>.
         </p>
-        <program interactive="activecode" language="java">
+        <program xml:id = "file-class-import-example" interactive="activecode" language="java">
             <code>
             import java.io.File;
             import java.io.IOException;public class Main {
@@ -56,10 +83,7 @@
 
         <pre>
             import java.io.IOException;
-        </pre>
-
-        <pre>
-            import java.io.FileNotFoundException 
+            import java.io.FileNotFoundException;
         </pre>
         
     </section>

--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -16,9 +16,6 @@
         <p>
             In Python, most built-in libraries are available without needing  to explicitly import additional packages, but some libraries like <c>math</c> do need to be imported. Consider the following.
         </p>
-        <p>
-            Python:
-        </p>
         <program xml:id = "file-class-import-Python-example" interactive="activecode" language="python">
             <code>
             import math
@@ -27,7 +24,7 @@
         </program>
 
         <p>
-            Java:
+            The same program in Java would look like this:
         </p>
         <program xml:id = "file-class-import-Java-example" interactive="activecode" language="java">
             <code>

--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -42,7 +42,7 @@
         </p>
 
         <p>
-            Java has several libraries included for file handling, though, they must be imported. Java includes a class called <c>File</c> in the <c>io</c> library. The class can be imported with the following line. Be sure to capitalize <c>File</c>.
+             Java includes a class called <c>File</c> in the <c>io</c> library. The class can be imported with the following line. Be sure to capitalize <c>File</c>.
         </p>
         <program xml:id = "file-class-import-example" interactive="activecode" language="java">
             <code>


### PR DESCRIPTION
I added the two examples @pearcej gave me and implemented xml ids in all of the code blocks in this section. I also decided to merge the last two pre tags for aesthetic reasons. I think the new content flows well into the old.

<img width="865" height="870" alt="image" src="https://github.com/user-attachments/assets/ae349a37-7bce-4426-9179-b895186189d0" />
