### PR TITLE
Moved Naming Conventions to chapter 3

### DIFF
--- a/source/ch3_javadatatypes.ptx
+++ b/source/ch3_javadatatypes.ptx
@@ -798,6 +798,44 @@ public class HistoMap {
  Improve the program above to remove the punctuation. 
         </p>
     </section>
+
+    <section xml:id="naming-conventions">
+            <title>Naming Conventions</title>
+            <p>
+        It is worth pointing out that Java has some very handy naming conventions. It is advisable to both use meaningful names and to follow these naming conventions while developing software in Java for good maintenance and readability of code. 
+    </p>
+
+    <p>
+        <ul>
+            <li>
+                <p>
+                    Class names should be nouns that are written in UpperCamelCase, namely with the first letter of each word capitalized including the first. 
+                    For example, <c>ArrayList</c>, <c>Scanner</c>, <c>StringBuilder</c>, <c>System</c>, etc.
+                </p>
+            </li>
+
+            <li>
+                <p>
+                    Method names use lowerCamelCase which start with a verb that describes the action they perform. This means that method names start with a lower case letter, and use upper case for each internal-word method names. For example, <c>isInt()</c>, <c>nextLine()</c>, <c>getDenominator()</c>, <c>setNumerator()</c>, etc.
+                </p>
+            </li>
+
+            <li>
+                <p>
+                    Instance variables of a class start with a lower case letter and use lowerCamelCase like method names. For example, <c>count</c>, <c>totalAmount</c>, etc.
+                </p>
+            </li>
+
+            <li>
+                <p>
+                    Constants are in all upper case letters or in upper snake case, which also known as screaming snake case, and which is a naming convention in which each word is written in uppercase letters,  separated by underscores. 
+                    For example, <c>Math.MAXINT</c> or <c>MAX_INT</c>.
+                </p>
+            </li>
+        </ul>
+    </p>
+        </section>
+
 <section xml:id="chapter3_summary">
   <title>Summary &amp; Reading Questions</title>
     <p><ol label="1">

--- a/source/ch6_definingclasses.ptx
+++ b/source/ch6_definingclasses.ptx
@@ -430,43 +430,6 @@ public class Fraction {
                 </code> <tests> </tests>
             </program>
         </subsection>
-
-        <subsection>
-            <title>Naming Conventions</title>
-            <p>
-        It is worth pointing out that Java has some very handy naming conventions. It is advisable to both use meaningful names and to follow these naming conventions while developing software in Java for good maintenance and readability of code. 
-    </p>
-
-    <p>
-        <ul>
-            <li>
-                <p>
-                    Class names should be nouns that are written in UpperCamelCase, namely with the first letter of each word capitalized including the first. 
-                    For example, <c>ArrayList</c>, <c>Scanner</c>, <c>StringBuilder</c>, <c>System</c>, etc.
-                </p>
-            </li>
-
-            <li>
-                <p>
-                    Method names use lowerCamelCase which start with a verb that describes the action they perform. This means that method names start with a lower case letter, and use upper case for each internal-word method names. For example, <c>isInt()</c>, <c>nextLine()</c>, <c>getDenominator()</c>, <c>setNumerator()</c>, etc.
-                </p>
-            </li>
-
-            <li>
-                <p>
-                    Instance variables of a class start with a lower case letter and use lowerCamelCase like method names. For example, <c>count</c>, <c>totalAmount</c>, etc.
-                </p>
-            </li>
-
-            <li>
-                <p>
-                    Constants are in all upper case letters or in upper snake case, which also known as screaming snake case, and which is a naming convention in which each word is written in uppercase letters,  separated by underscores. 
-                    For example, <c>Math.MAXINT</c> or <c>MAX_INT</c>.
-                </p>
-            </li>
-        </ul>
-    </p>
-        </subsection>
     </section>
 
     <section xml:id="inheritance">


### PR DESCRIPTION
I felt that the end of Chapter 3 was a good place to put Naming Conventions. It is also a section instead of a subsection now and can easily be copy/pasted to other chapters.

Fixes issue #153.