### PR TITLE
Created input box for Java code in 4.5

### DIFF
--- a/source/ch4_conditionals.ptx
+++ b/source/ch4_conditionals.ptx
@@ -316,7 +316,7 @@ The <c>switch</c> statement is not used very often, and we recommend you do not 
                     }
                 }
             }
-            </code>
+            </code> <stdin> </stdin> <tests> </tests>
         </program>
 
         <p>


### PR DESCRIPTION
From what I can tell, `stdin` tags and `tests` tags are both used to the input boxes as seen in 3.1. I am not sure that this will work as I was unable to test functionality.

Fixes issue #150 