### PR TITLE
Issue135 unclear ref

### DIFF
--- a/source/ch3_javadatatypes.ptx
+++ b/source/ch3_javadatatypes.ptx
@@ -692,8 +692,8 @@ public class HistoArray {
         </program>
 
         <p>
- The main difference between this example and the previous example is that we declare <c>count</c> to be an <c>Array</c> of integers. We also can initialize short arrays directly using the syntax shown on line 7. Then notice that on line 22 we can use the square bracket notation to index into an array. 
-        </p>
+  The main difference between this example and the previous example is that we declare <c>count</c> to be an <c>Array</c> of integers. We also can initialize short arrays directly using the syntax shown here: <c>Integer[] count = {0,0,0,0,0,0,0,0,0,0}</c>Then notice that we can use the square bracket notation <c>count[idx]</c> to index into an array.
+</p>
     </section>
 
     <section xml:id="dictionary">

--- a/source/ch3_javadatatypes.ptx
+++ b/source/ch3_javadatatypes.ptx
@@ -692,7 +692,7 @@ public class HistoArray {
         </program>
 
         <p>
- The main difference between this example and the previous example is that we declare <c>count</c> to be an <c>Array</c> of integers. We also can initialize short arrays directly using the syntax shown on line 8. Then notice that on line 22 we can use the square bracket notation to index into an array. 
+ The main difference between this example and the previous example is that we declare <c>count</c> to be an <c>Array</c> of integers. We also can initialize short arrays directly using the syntax shown on line 7. Then notice that on line 22 we can use the square bracket notation to index into an array. 
         </p>
     </section>
 


### PR DESCRIPTION
#Description
Removed incorrect line number references in the section 3.5 ("line 8" and "line 22" were both wrong). Replaced them with inline code tags showing the actual code snippets directly in the paragraph to avoid future line number issues.

Fixes #135 
<img width="946" height="220" alt="image" src="https://github.com/user-attachments/assets/6edc168d-32bc-428a-a4ed-620edaacefe4" />

Tested on local build
