### PR TITLE
Issue 222: 3.2 list, comment, activecode

### DIFF
--- a/source/ch3_javadatatypes.ptx
+++ b/source/ch3_javadatatypes.ptx
@@ -294,13 +294,13 @@ public class TempConv {
         </p>
 
         <p>
-            Implicit typecasting happens automatically when converting a value from a smaller data type to a larger one, as there is no risk of losing information. For example, you can assign an int to a double without any special syntax. 
+            Implicit typecasting happens automatically when converting a value from a smaller data type to a larger one, as there is no risk of losing information. For example, you can assign an int to a double without any special syntax as shown in <xref ref="implicit-typecasting" text="type-global"/>. 
         </p>
 
         <listing xml:id="implicit-typecasting">
         <program interactive="activecode" language="java">
             <code>
-        void main() {
+void main() {
     int myInt = 10;
     double myDouble = myInt; // Automatic casting from int to double
 
@@ -311,7 +311,7 @@ public class TempConv {
         </listing>
 
         <p>
-            Explicit typecasting is required when converting from a larger data type to a smaller one, as you might lose data. You must do this manually by placing the target type in parentheses () before the value.
+            Explicit typecasting is required when converting from a larger data type to a smaller one, as you might lose data. You must do this manually by placing the target type in parentheses () before the value as shown in <xref ref="explicit-typecasting" text="type-global"/>.
         </p>
         <listing xml:id="explicit-typecasting">
         <program interactive="activecode" language="java">
@@ -330,7 +330,7 @@ void main() {
         Besides primitive types, type casting is also a fundamental concept when working with objects, especially within an inheritance hierarchy. This involves converting an object reference from one class type to another, typically between a superclass and a subclass. This is often referred to as upcasting and downcasting.
     </p>
     <p>
-        Let's imagine we have a simple class hierarchy: an <c>Animal</c> superclass and a <c>Dog</c> subclass.
+        In <xref ref="animal-dog-example" text="type-global"/>, we have a simple class hierarchy: an <c>Animal</c> superclass and a <c>Dog</c> subclass.
     </p>
 
     <listing xml:id="animal-dog-example">
@@ -353,7 +353,7 @@ class Dog extends Animal {
     </listing>
 
     <p>
-        <strong>Upcasting (Implicit):</strong> Upcasting is casting a subclass instance to a superclass reference type. This is always safe because a subclass object is guaranteed to have all the methods and properties of its superclass. Therefore, upcasting is done implicitly by the compiler.
+        <strong>Upcasting (Implicit):</strong> Upcasting is casting a subclass instance to a superclass reference type. This is always safe because a subclass object is guaranteed to have all the methods and properties of its superclass. Therefore, upcasting is done implicitly by the compiler as <xref ref="upcasting-example" text="type-global"/>.
     </p>
     <listing xml:id="upcasting-example">
     <program interactive="activecode" language="java">
@@ -388,7 +388,7 @@ void main() {
         <strong>Downcasting (Explicit):</strong> Downcasting is casting a superclass reference back to its original subclass type. This is potentially unsafe because the superclass reference might not actually point to an object of the target subclass. You must perform an explicit cast. If you cast to the wrong type, Java will throw a <c>ClassCastException</c> at runtime.
     </p>
     <p>
-        To safely downcast, you should first check the object's type using the <c>instanceof</c> operator.
+        To safely downcast, you should first check the object's type using the <c>instanceof</c> operator as shown in <xref ref="downcasting-example" text="type-global"/>.
     </p>
     <listing xml:id="downcasting-example">
     <program interactive="activecode" language="java">
@@ -421,7 +421,7 @@ void main() {
     </listing>
 
         <p>
-            In this example, we first create a <c>Dog</c> object and assign it to an <c>Animal</c> reference (upcasting). Then, we check if the <c>Animal</c> reference is actually pointing to a <c>Dog</c> object before downcasting it back to a <c>Dog</c> reference.
+            In <xref ref="downcasting-example" text="type-global"/>, we first create a <c>Dog</c> object and assign it to an <c>Animal</c> reference (upcasting). Then, we check if the <c>Animal</c> reference is actually pointing to a <c>Dog</c> object before downcasting it back to a <c>Dog</c> reference.
         </p>
         </section>
 

--- a/source/ch3_javadatatypes.ptx
+++ b/source/ch3_javadatatypes.ptx
@@ -336,13 +336,18 @@ void main() {
     <listing xml:id="animal-dog-example">
     <program language="java">
         <code>
+/**
+    * Animal class is the superclass, with a method makeSound().
+    */        
 class Animal {
-
     public void makeSound() {
         System.out.println("The animal makes a sound.");
     }
 }
 
+/**
+    * Dog class is a subclass of Animal, with an additional method bark().
+    */
 class Dog extends Animal {
     public void bark() {
         System.out.println("The dog barks!");
@@ -358,18 +363,28 @@ class Dog extends Animal {
     <listing xml:id="upcasting-example">
     <program interactive="activecode" language="java">
         <code>
+
+/**
+    * Animal class is the superclass, with a method makeSound().
+    */
 class Animal {
     public void makeSound() {
         System.out.println("The animal makes a sound.");
     }
 }
 
+/**
+    * Dog class is a subclass of Animal, with an additional method bark().
+    */
 class Dog extends Animal {
     public void bark() {
         System.out.println("The dog barks!");
     }
 }
 
+/**
+    * Upcasting example: A Dog object is created, but the reference is of type Animal.   
+    */ 
 void main() {
 // A Dog object is created, but the reference is of type Animal.
 // This is implicit upcasting.
@@ -377,8 +392,8 @@ void main() {
 
     myAnimal.makeSound(); // This is valid, as makeSound() is defined in Animal.
 
-// myAnimal.bark(); // This would cause a compile-time error!
-// The compiler only knows about the methods in the Animal reference type.
+    // myAnimal.bark(); // This would cause a compile-time error!
+    // The compiler only knows about the methods in the Animal reference type.
 }
     </code>
     </program>
@@ -393,20 +408,28 @@ void main() {
     <listing xml:id="downcasting-example">
     <program interactive="activecode" language="java">
         <code>
+/**
+    * Animal class is the superclass, with a method makeSound().
+    */       
 class Animal {
     public void makeSound() {
         System.out.println("The animal makes a sound.");
     }
 }
 
+/**
+    * Dog class is a subclass of Animal, with an additional method bark().
+    */
 class Dog extends Animal {
     public void bark() {
         System.out.println("The dog barks!");
     }
 }
 
+/**
+    * Downcasting example: An Animal reference is downcast to a Dog reference after checking its type.
+    */
 void main() { 
-
     Animal myAnimal = new Dog();
 
     // 'myAnimal' is an Animal reference, but it points to a Dog object. 

--- a/source/ch3_javadatatypes.ptx
+++ b/source/ch3_javadatatypes.ptx
@@ -296,18 +296,35 @@ public class TempConv {
         <p>
             Implicit typecasting happens automatically when converting a value from a smaller data type to a larger one, as there is no risk of losing information. For example, you can assign an int to a double without any special syntax. 
         </p>
-        <pre> 
-        int myInt = 10;
-        double myDouble = myInt; // Automatic casting from int to double
-        </pre>
-            
+
+        <listing xml:id="implicit-typecasting">
+        <program interactive="activecode" language="java">
+            <code>
+        void main() {
+    int myInt = 10;
+    double myDouble = myInt; // Automatic casting from int to double
+
+    System.out.println(myDouble); 
+} 
+         </code>
+        </program>
+        </listing>
+
         <p>
             Explicit typecasting is required when converting from a larger data type to a smaller one, as you might lose data. You must do this manually by placing the target type in parentheses () before the value.
         </p>
-        <pre>
-        double originalDouble = 9.78;
-        int castedInt = (int) originalDouble; // Explicitly casts double to int. The value of castedInt is now 9.
-        </pre>
+        <listing xml:id="explicit-typecasting">
+        <program interactive="activecode" language="java">
+            <code>
+void main() {
+    double originalDouble = 9.78;
+    int castedInt = (int) originalDouble; // Explicitly casts double to int. The value of castedInt is now 9.
+
+    System.out.println(castedInt); 
+}
+            </code>
+        </program>
+        </listing>
 
         <p>
         Besides primitive types, type casting is also a fundamental concept when working with objects, especially within an inheritance hierarchy. This involves converting an object reference from one class type to another, typically between a superclass and a subclass. This is often referred to as upcasting and downcasting.
@@ -315,7 +332,32 @@ public class TempConv {
     <p>
         Let's imagine we have a simple class hierarchy: an <c>Animal</c> superclass and a <c>Dog</c> subclass.
     </p>
-    <pre>
+
+    <listing xml:id="animal-dog-example">
+    <program language="java">
+        <code>
+class Animal {
+
+    public void makeSound() {
+        System.out.println("The animal makes a sound.");
+    }
+}
+
+class Dog extends Animal {
+    public void bark() {
+        System.out.println("The dog barks!");
+    }
+}
+    </code>
+    </program>
+    </listing>
+
+    <p>
+        <strong>Upcasting (Implicit):</strong> Upcasting is casting a subclass instance to a superclass reference type. This is always safe because a subclass object is guaranteed to have all the methods and properties of its superclass. Therefore, upcasting is done implicitly by the compiler.
+    </p>
+    <listing xml:id="upcasting-example">
+    <program interactive="activecode" language="java">
+        <code>
 class Animal {
     public void makeSound() {
         System.out.println("The animal makes a sound.");
@@ -327,37 +369,56 @@ class Dog extends Animal {
         System.out.println("The dog barks!");
     }
 }
-    </pre>
 
-    <p>
-        <strong>Upcasting (Implicit):</strong> Upcasting is casting a subclass instance to a superclass reference type. This is always safe because a subclass object is guaranteed to have all the methods and properties of its superclass. Therefore, upcasting is done implicitly by the compiler.
-    </p>
-    <pre>
+void main() {
 // A Dog object is created, but the reference is of type Animal.
 // This is implicit upcasting.
-Animal myAnimal = new Dog(); 
+    Animal myAnimal = new Dog(); 
 
-myAnimal.makeSound(); // This is valid, as makeSound() is defined in Animal.
+    myAnimal.makeSound(); // This is valid, as makeSound() is defined in Animal.
 
 // myAnimal.bark(); // This would cause a compile-time error!
 // The compiler only knows about the methods in the Animal reference type.
-    </pre>
+}
+    </code>
+    </program>
+    </listing>
+
     <p>
         <strong>Downcasting (Explicit):</strong> Downcasting is casting a superclass reference back to its original subclass type. This is potentially unsafe because the superclass reference might not actually point to an object of the target subclass. You must perform an explicit cast. If you cast to the wrong type, Java will throw a <c>ClassCastException</c> at runtime.
     </p>
     <p>
         To safely downcast, you should first check the object's type using the <c>instanceof</c> operator.
     </p>
-    <pre>
-// 'myAnimal' is an Animal reference, but it points to a Dog object.
-if (myAnimal instanceof Dog) {
-    // The check passed, so this downcast is safe.
-    Dog myDog = (Dog) myAnimal;
-
-    // Now we can access methods specific to the Dog class.
-    myDog.bark(); // This is now valid.
+    <listing xml:id="downcasting-example">
+    <program interactive="activecode" language="java">
+        <code>
+class Animal {
+    public void makeSound() {
+        System.out.println("The animal makes a sound.");
+    }
 }
-    </pre>
+
+class Dog extends Animal {
+    public void bark() {
+        System.out.println("The dog barks!");
+    }
+}
+
+void main() { 
+
+    Animal myAnimal = new Dog();
+
+    // 'myAnimal' is an Animal reference, but it points to a Dog object. 
+    if (myAnimal instanceof Dog myDog) {
+        // Now we can access methods specific to the Dog class.
+        myDog.bark();
+    }
+}
+    
+    </code>
+    </program>
+    </listing>
 
         <p>
             In this example, we first create a <c>Dog</c> object and assign it to an <c>Animal</c> reference (upcasting). Then, we check if the <c>Animal</c> reference is actually pointing to a <c>Dog</c> object before downcasting it back to a <c>Dog</c> reference.


### PR DESCRIPTION
## Description 
Added listing, active block, and comments to the code sections in 3.2

_Note_: All of the code blocks below are active code and can run without any errors in the Runestone book, except for listing 3.2.3, which is just to show the classes.
 
## Issue Fix 
fixes #222 
fixes #223

## Screenshot 

<img width="578" height="676" alt="image" src="https://github.com/user-attachments/assets/1764e9d9-3475-4e30-892e-87b6f59e85be" />

<img width="608" height="504" alt="image" src="https://github.com/user-attachments/assets/58e89d9b-45e9-4a32-9121-69bb7eb8d0d8" />


<img width="587" height="763" alt="image" src="https://github.com/user-attachments/assets/55903dc8-561a-4fdb-a90d-3c3d4b9107c4" />

<img width="576" height="896" alt="image" src="https://github.com/user-attachments/assets/38a36fec-f99e-46e1-b74f-4957cd074347" />

## Tested 
Local Build
Java code block in the Runestone version 