### PR TITLE
Issue 335: 8.4 listing

### DIFF
--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -240,7 +240,7 @@ public class CreateFile {
         </p>
 
         <p>
-            Let us create the framework for a class that will write to a file. Let's call this class <c>WriteFile</c>:
+            <xref ref="write-file-class-java" text="type-global"/> shows the framework for a class that will write to a file. Let's call this class <c>WriteFile</c>.
         </p>
 
         <listing xml:id="write-file-class-java">
@@ -258,7 +258,7 @@ public class CreateFile {
         </listing>
         
         <p>
-            Next, we will create a <c>FileWriter</c> object. Let's call it <c>myWriter</c>. The equivalent Python code to this operation is:
+            Next, we will create a <c>FileWriter</c> object. Let's call it <c>myWriter</c>. <xref ref="filerwriter-object-python" text="type-global"/> shows the code to create a <c>myWriter</c> object in Python.
         </p>
         <listing xml:id="filerwriter-object-python">
         <program language="python">
@@ -267,7 +267,7 @@ public class CreateFile {
         </listing>
 
         <p>
-            The Java code to create a <c>FileWriter</c> object is:
+            <xref ref="filerwriter-object-java" text="type-global"/> shows the Java code to create a <c>FileWriter</c> object. Note that the <c>FileWriter</c> object is created with the name of the file to write to as an argument. If the file does not exist, it will be created. If it does exist, it will be overwritten.:
         </p>
 
         <listing xml:id="filerwriter-object-java">
@@ -277,7 +277,7 @@ public class CreateFile {
         </listing>
 
         <p>
-            In this next step, we will use the <c>write()</c> method from the FileWriter class. This method will take any data within the parenthesis and write that data to the file selected. The <c>write()</c> method takes most standard data types. First, how this step is completed with Python:
+            In this next step, we will use the <c>write()</c> method from the FileWriter class. This method will take any data within the parenthesis and write that data to the file selected. The <c>write()</c> method takes most standard data types. The <xref ref="write-and-close-python" text="type-global"/> shows the code to write to a file in Python.
         </p>
         <listing xml:id="write-and-close-python">
         <program language="python">
@@ -286,7 +286,7 @@ public class CreateFile {
         </listing>
 
         <p>
-            And the Java equivalent. This is almost completely identical except for the second line, which is very important!
+            <xref ref="write-and-close-java" text="type-global"/> shows the Java equivalent. This is almost completely identical except for the second line, which is very important!
         </p>
 
         <listing xml:id="write-and-close-java">
@@ -303,7 +303,7 @@ public class CreateFile {
         </note>
 
         <p>
-            Next, we will again add the required try/catch blocks utilizing the <c>IOException</c> class. Just like with creating files, the program will not compile without these crucial additions! We will also add some print statements to inform us of the success of the file write operation. First, a Python example:
+            Next, we will again add the required try/catch blocks utilizing the <c>IOException</c> class. Just like with creating files, the program will not compile without these crucial additions! We will also add some print statements to inform us of the success of the file write operation. <xref ref="file-try-catch-python" text="type-global"/> shows the code to write to a file in Python.
         </p>
         
         <listing xml:id="file-try-catch-python">
@@ -320,7 +320,7 @@ public class CreateFile {
         </listing>
 
         <p>
-            And the equivalent Java code:
+           <xref ref="file-try-catch-java" text="type-global"/> shows the Java equivalent. 
         </p>
 
         <listing xml:id="file-try-catch-java">
@@ -338,7 +338,7 @@ public class CreateFile {
         </listing>
 
         <p>
-            And that's it! We will add our code to the foundational code for a complete program. First, an example of equivalent Python code:
+            And that's it! We will add our code to the foundational code for a complete program. First, <xref ref="file-write-full-python" text="type-global"/> shows the completed Python code.
         </p>
         <data xml:id="my-file-8-4-2">
             <title>Data file for writing example</title>
@@ -365,7 +365,7 @@ public class CreateFile {
         </listing>
 
         <p>
-            The completed Java code:
+           <xref ref="file-write-full-java" text="type-global"/> shows the completed Java code. 
         </p>
         <data xml:id="my-file-8-4-5">
             <title>Data file for writing example</title>
@@ -403,7 +403,7 @@ public class CreateFile {
         </note>
 
         <p>
-            Speaking of overwriting data, what if we want to append text to the end of any text already in <c>myfile.txt</c>? To accomplish this, we can pass a <c>boolean</c> argument along with the file name when creating a new data argument:
+            Speaking of overwriting data, what if we want to append text to the end of any text already in <c>myfile.txt</c>? To accomplish this, we can pass a <c>boolean</c> argument along with the file name when creating a new data argument as shown in <xref ref="append-true" text="type-global"/>. 
         </p>
 
         <listing xml:id="append-true">
@@ -413,8 +413,8 @@ public class CreateFile {
         </listing>
 
         <p>
-            Now, when we use <c>write()</c> method like before, the text will be appended if there is already tSext in the document. If we were to update our code to include the <c>boolean</c> argument:
-        </p>
+            Now, when we use <c>write()</c> method like before, the text will be appended if there is already tSext in the document. If we were to update our code to include the <c>boolean</c> argument as shown in <xref ref="file-write-with-append" text="type-global"/>. 
+
         <data xml:id="my-file-8-4-6">
             <title>Data file for writing example</title>
         <datafile label="my-file-8-4-6" filename="myfile" editable="yes">
@@ -448,7 +448,7 @@ public class CreateFile {
         </listing>
 
         <p>
-            Then if we run the program twice, the contents of <c>myfile.txt</c> would be:
+            Then if we run the program twice, the contents of <c>myfile.txt</c> would be as <xref ref="file-write-with-append-output" text="type-global"/> shows.
         </p>
 
         <listing xml:id="file-write-with-append-output">
@@ -458,7 +458,7 @@ public class CreateFile {
         </listing>
 
         <p>
-            This doesn't look very good! If we want each additional write to appear on a new line? A simple solution is to use the <c>\n</c> newline character:
+            This doesn't look very good! If we want each additional write to appear on a new line? A simple solution is to use the <c>\n</c> newline character as <xref ref="file-write-with-newline" text="type-global"/> shows.
         </p>
 
         <listing xml:id="file-write-with-newline">
@@ -469,7 +469,7 @@ public class CreateFile {
         </listing>
 
         <p>
-            Running the code with the newline character twice will result in the following contents in myfile.txt:
+            Running the code with the newline character twice will result in the following contents in myfile.txt as <xref ref="file-write-with-newline-output" text="type-global"/> shows.
         </p>
 
         <listing xml:id="file-write-with-newline-output">

--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -418,6 +418,7 @@ public class CreateFile {
 
         <p>
             Now, when we use <c>write()</c> method like before, the text will be appended if there is already tSext in the document. If we were to update our code to include the <c>boolean</c> argument as shown in <xref ref="file-write-with-append" text="type-global"/>. 
+        </p>
 
         <data xml:id="data-file-write-with-append">
             <title>Data file for writing example</title>

--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -374,7 +374,10 @@ public class CreateFile {
                     
                 </pre>
             </datafile>
-        <program xml:id="file-write-full-java" interactive="activecode" language="java" add-files = "data-file-write-full-java">
+            </data>
+
+        <listing xml:id="file-write-full-java">
+        <program interactive="activecode" language="java" add-files = "data-file-write-full-java">
             <code>
             import java.io.FileWriter;
             import java.io.IOException;
@@ -394,7 +397,8 @@ public class CreateFile {
             }
             </code> 
         </program>
-        </data>
+        </listing>
+        
 
         <note>
             <p>

--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -340,9 +340,10 @@ public class CreateFile {
         <p>
             And that's it! We will add our code to the foundational code for a complete program. First, <xref ref="file-write-full-python" text="type-global"/> shows the completed Python code.
         </p>
-        <data xml:id="data-file-write-full-python">
+
+        <data xml:id="listing-data-file-write-full-python">
             <title>Data file for writing example</title>
-        <datafile label="data-file-write-full-python" filename="myfile.txt" editable="yes">
+        <datafile xml:id="data-file-write-full-python" label="data-file-write-full-python" filename="myfile.txt" editable="yes">
                 <pre>
                     
                 </pre>
@@ -367,9 +368,9 @@ public class CreateFile {
         <p>
            <xref ref="file-write-full-java" text="type-global"/> shows the completed Java code. 
         </p>
-        <data xml:id="data-file-write-full-java">
+        <data xml:id="listing-data-file-write-full-java">
             <title>Data file for writing example</title>
-        <datafile label="data-file-write-full-java" filename="myfile.txt" editable="yes">
+        <datafile xml:id="data-file-write-full-java" label="data-file-write-full-java" filename="myfile.txt" editable="yes">
                 <pre>
                     
                 </pre>
@@ -395,7 +396,7 @@ public class CreateFile {
                     }
                 }
             }
-            </code> 
+            </code> ~
         </program>
         </listing>
         
@@ -420,9 +421,9 @@ public class CreateFile {
             Now, when we use <c>write()</c> method like before, the text will be appended if there is already tSext in the document. If we were to update our code to include the <c>boolean</c> argument as shown in <xref ref="file-write-with-append" text="type-global"/>. 
         </p>
 
-        <data xml:id="data-file-write-with-append">
+        <data xml:id="listing-data-file-write-with-append">
             <title>Data file for writing example</title>
-        <datafile label="data-file-write-with-append" filename="myfile" editable="yes">
+        <datafile xml:id="data-file-write-with-append" label="data-file-write-with-append" filename="myfile" editable="yes">
                 <pre>
                     
                 </pre>
@@ -467,7 +468,7 @@ public class CreateFile {
         </p>
 
         <listing xml:id="file-write-with-newline">
-        <program  language="java">
+        <program language="java">
             myWriter.write("File successfully updated!\n"); // Added newline character 
             myWriter.close(); 
         </program>

--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -451,9 +451,11 @@ public class CreateFile {
             Then if we run the program twice, the contents of <c>myfile.txt</c> would be:
         </p>
 
-        <pre>
+        <listing xml:id="file-write-with-append-output">
+        <program>
             File successfully updated!File successfully updated!
-        </pre>
+        </program>
+        </listing>
 
         <p>
             This doesn't look very good! If we want each additional write to appear on a new line? A simple solution is to use the <c>\n</c> newline character:
@@ -469,11 +471,14 @@ public class CreateFile {
         <p>
             Running the code with the newline character twice will result in the following contents in myfile.txt:
         </p>
-        
-        <pre>
+
+        <listing xml:id="file-write-with-newline-output">
+        <program>
             File successfully updated!
             File successfully updated!
-        </pre>
+        </program>
+        </listing>
+
     </section>
 
     <section xml:id="file-delete">

--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -242,8 +242,9 @@ public class CreateFile {
         <p>
             Let us create the framework for a class that will write to a file. Let's call this class <c>WriteFile</c>:
         </p>
-        
-        <program xml:id="write-file-class-java" language="java">
+
+        <listing xml:id="write-file-class-java">
+        <program language="java">
             import java.io.File;
             import java.io.FileWriter;
             import java.io.IOException;
@@ -254,39 +255,46 @@ public class CreateFile {
                 }
             }
         </program>
+        </listing>
         
         <p>
             Next, we will create a <c>FileWriter</c> object. Let's call it <c>myWriter</c>. The equivalent Python code to this operation is:
         </p>
-
-        <program xml:id="filerwriter-object-python" language="python">
+        <listing xml:id="filerwriter-object-python">
+        <program language="python">
             with open("myfile.txt", "w") as myWriter:
         </program>
+        </listing>
 
         <p>
             The Java code to create a <c>FileWriter</c> object is:
         </p>
 
-        <program xml:id="filerwriter-object-java" language="java">
+        <listing xml:id="filerwriter-object-java">
+        <program language="java">
             FileWriter myWriter = new FileWriter("myfile.txt");
         </program>
+        </listing>
 
         <p>
             In this next step, we will use the <c>write()</c> method from the FileWriter class. This method will take any data within the parenthesis and write that data to the file selected. The <c>write()</c> method takes most standard data types. First, how this step is completed with Python:
         </p>
-        
-        <program xml:id="write-and-close-python" language="python">
+        <listing xml:id="write-and-close-python">
+        <program language="python">
             my_writer.write("File successfully updated!")
         </program>
+        </listing>
 
         <p>
             And the Java equivalent. This is almost completely identical except for the second line, which is very important!
         </p>
 
-        <program xml:id="write-and-close-java" language="java">
+        <listing xml:id="write-and-close-java">
+        <program language="java">
             myWriter.write("File successfully updated!");
             myWriter.close();
         </program>
+        </listing>
 
         <note>
             <p>
@@ -298,7 +306,8 @@ public class CreateFile {
             Next, we will again add the required try/catch blocks utilizing the <c>IOException</c> class. Just like with creating files, the program will not compile without these crucial additions! We will also add some print statements to inform us of the success of the file write operation. First, a Python example:
         </p>
         
-        <program xml:id="file-try-catch-python" language="python" add-files = "my-file-8-4-2">
+        <listing xml:id="file-try-catch-python">
+        <program language="python" add-files = "my-file-8-4-2">
                 try:
                     with open("myfile.txt", "w") as my_writer:
                         my_writer.write("File successfully updated!")
@@ -308,12 +317,14 @@ public class CreateFile {
                     import traceback
                     traceback.print_exc()
         </program>
+        </listing>
 
         <p>
             And the equivalent Java code:
         </p>
 
-        <program language="java" xml:id="file-try-catch-java">
+        <listing xml:id="file-try-catch-java">
+        <program language="java">
             try {
                 FileWriter myWriter = new FileWriter("myfile.txt");
                 myWriter.write("File successfully updated!");
@@ -324,16 +335,22 @@ public class CreateFile {
                 e.printStackTrace();
             }
         </program>
+        </listing>
 
         <p>
             And that's it! We will add our code to the foundational code for a complete program. First, an example of equivalent Python code:
         </p>
+        <data xml:id="my-file-8-4-2">
+            <title>Data file for writing example</title>
         <datafile label="my-file-8-4-4" filename="myfile.txt" xml:id= "my-file-8-4-4" editable="yes">
                 <pre>
                     
                 </pre>
         </datafile>
-        <program xml:id="file-write-full-python" interactive="activecode" language="python" add-files="my-file-8-4-4">
+        </data>
+
+        <listing xml:id="file-write-full-python">
+        <program interactive="activecode" language="python" add-files="my-file-8-4-4">
             <code>
             try:
                 with open("myfile.txt", "w") as my_writer:
@@ -345,10 +362,13 @@ public class CreateFile {
                 traceback.print_exc()
             </code> 
         </program>
+        </listing>
 
         <p>
             The completed Java code:
         </p>
+        <data xml:id="my-file-8-4-5">
+            <title>Data file for writing example</title>
         <datafile label="my-file-8-4-5" filename="myfile.txt" xml:id= "my-file-8-4-5" editable="yes">
                 <pre>
                     
@@ -374,6 +394,7 @@ public class CreateFile {
             }
             </code> 
         </program>
+        </data>
 
         <note>
             <p>
@@ -385,19 +406,26 @@ public class CreateFile {
             Speaking of overwriting data, what if we want to append text to the end of any text already in <c>myfile.txt</c>? To accomplish this, we can pass a <c>boolean</c> argument along with the file name when creating a new data argument:
         </p>
 
-        <program xml:id="append-true" language="java">
+        <listing xml:id="append-true">
+        <program language="java">
             FileWriter myWriter = new FileWriter("myfile.txt", true); // true enables append mode
         </program>
+        </listing>
 
         <p>
             Now, when we use <c>write()</c> method like before, the text will be appended if there is already tSext in the document. If we were to update our code to include the <c>boolean</c> argument:
         </p>
-        <datafile label="my-file-8-4-6" filename="myfile" xml:id= "my-file-8-4-6" editable="yes">
+        <data xml:id="my-file-8-4-6">
+            <title>Data file for writing example</title>
+        <datafile label="my-file-8-4-6" filename="myfile" editable="yes">
                 <pre>
                     
                 </pre>
             </datafile>
-        <program xml:id="file-write-with-append" interactive="activecode" language="java" add-files = "my-file-8-4-6">
+        </data>
+
+        <listing xml:id="file-write-with-append">
+        <program interactive="activecode" language="java" add-files = "my-file-8-4-6">
             <code>
             import java.io.FileWriter;
             import java.io.IOException;
@@ -417,6 +445,7 @@ public class CreateFile {
             }
             </code> 
         </program>
+        </listing>
 
         <p>
             Then if we run the program twice, the contents of <c>myfile.txt</c> would be:
@@ -430,15 +459,17 @@ public class CreateFile {
             This doesn't look very good! If we want each additional write to appear on a new line? A simple solution is to use the <c>\n</c> newline character:
         </p>
 
-        <program xml:id="newline" language="java">
+        <listing xml:id="file-write-with-newline">
+        <program  language="java">
             myWriter.write("File successfully updated!\n"); // Added newline character 
             myWriter.close(); 
         </program>
+        </listing>
 
         <p>
             Running the code with the newline character twice will result in the following contents in myfile.txt:
         </p>
-
+        
         <pre>
             File successfully updated!
             File successfully updated!

--- a/source/ch8_filehandling.ptx
+++ b/source/ch8_filehandling.ptx
@@ -340,9 +340,9 @@ public class CreateFile {
         <p>
             And that's it! We will add our code to the foundational code for a complete program. First, <xref ref="file-write-full-python" text="type-global"/> shows the completed Python code.
         </p>
-        <data xml:id="my-file-8-4-2">
+        <data xml:id="data-file-write-full-python">
             <title>Data file for writing example</title>
-        <datafile label="my-file-8-4-4" filename="myfile.txt" xml:id= "my-file-8-4-4" editable="yes">
+        <datafile label="data-file-write-full-python" filename="myfile.txt" editable="yes">
                 <pre>
                     
                 </pre>
@@ -350,7 +350,7 @@ public class CreateFile {
         </data>
 
         <listing xml:id="file-write-full-python">
-        <program interactive="activecode" language="python" add-files="my-file-8-4-4">
+        <program interactive="activecode" language="python" add-files="data-file-write-full-python">
             <code>
             try:
                 with open("myfile.txt", "w") as my_writer:
@@ -367,14 +367,14 @@ public class CreateFile {
         <p>
            <xref ref="file-write-full-java" text="type-global"/> shows the completed Java code. 
         </p>
-        <data xml:id="my-file-8-4-5">
+        <data xml:id="data-file-write-full-java">
             <title>Data file for writing example</title>
-        <datafile label="my-file-8-4-5" filename="myfile.txt" xml:id= "my-file-8-4-5" editable="yes">
+        <datafile label="data-file-write-full-java" filename="myfile.txt" editable="yes">
                 <pre>
                     
                 </pre>
             </datafile>
-        <program xml:id="file-write-full-java" interactive="activecode" language="java" add-files = "my-file-8-4-5">
+        <program xml:id="file-write-full-java" interactive="activecode" language="java" add-files = "data-file-write-full-java">
             <code>
             import java.io.FileWriter;
             import java.io.IOException;
@@ -415,9 +415,9 @@ public class CreateFile {
         <p>
             Now, when we use <c>write()</c> method like before, the text will be appended if there is already tSext in the document. If we were to update our code to include the <c>boolean</c> argument as shown in <xref ref="file-write-with-append" text="type-global"/>. 
 
-        <data xml:id="my-file-8-4-6">
+        <data xml:id="data-file-write-with-append">
             <title>Data file for writing example</title>
-        <datafile label="my-file-8-4-6" filename="myfile" editable="yes">
+        <datafile label="data-file-write-with-append" filename="myfile" editable="yes">
                 <pre>
                     
                 </pre>
@@ -425,7 +425,7 @@ public class CreateFile {
         </data>
 
         <listing xml:id="file-write-with-append">
-        <program interactive="activecode" language="java" add-files = "my-file-8-4-6">
+        <program interactive="activecode" language="java" add-files = "data-file-write-with-append">
             <code>
             import java.io.FileWriter;
             import java.io.IOException;


### PR DESCRIPTION
## Description 
Add listing tags to code blocks 

**"Another issue will tackle the code blocks themselves not working"**

## Issue Fix 
fixes #335 
## Screenshot 
<img width="858" height="975" alt="image" src="https://github.com/user-attachments/assets/910f9df2-3cb6-4277-a5b3-1c41cbd09182" />
<img width="787" height="988" alt="image" src="https://github.com/user-attachments/assets/5c666d9b-1415-4c31-8de3-6d4534de4b3b" />
<img width="889" height="962" alt="image" src="https://github.com/user-attachments/assets/7317e9d0-ba61-4698-8626-3146ad3a07f2" />
<img width="941" height="928" alt="image" src="https://github.com/user-attachments/assets/2348833c-66bd-494b-a6da-748ada917169" />
<img width="869" height="961" alt="image" src="https://github.com/user-attachments/assets/4da4cfe2-faf9-45a3-b61a-da789999a0f5" />
<img width="935" height="614" alt="image" src="https://github.com/user-attachments/assets/21d82f0f-0f8e-4388-8117-0d9025671606" />


## Tested
Local Build (To see the format of the listing tags only not the code) 